### PR TITLE
Setup: force installation/inclusion of runtimes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -700,12 +700,29 @@ if __name__ == '__main__':
                 'nt': "any of the directories in %%PATH%%.",
             }[os.name]
 
-            print_warning(
-                "Could not find the %s runtime." % package.name,
-                "The %(name)s shared library was *not* found in %(loc)s "
-                "In case of runtime problems, please remember to install it."
-                % dict(name=package.name, loc=loc)
-            )
+            if "bdist_wheel" in sys.argv:
+                exit_with_error(
+                    "Could not find the %s runtime." % package.name,
+                    "The %(name)s shared library was *not* found in %(loc)s "
+                    "Cannot build wheel without the runtime."
+                    % dict(name=package.name, loc=loc)
+                )
+            elif "install" in sys.argv and os.name == "nt":
+                # for python >= 3.8 on Windows we need to install the DLLs
+                # alongside of the python package for DLL import to work
+                exit_with_error(
+                    "Could not find the %s runtime." % package.name,
+                    "The %(name)s shared library was *not* found in %(loc)s "
+                    "Runtime must be installed alongside of the tables package."
+                    % dict(name=package.name, loc=loc)
+                )
+            else:
+                print_warning(
+                    "Could not find the %s runtime." % package.name,
+                    "The %(name)s shared library was *not* found in %(loc)s "
+                    "In case of runtime problems, please remember to install it."
+                    % dict(name=package.name, loc=loc)
+                )
 
         if os.name == "nt":
             # LZO DLLs cannot be copied to the binary package for license reasons


### PR DESCRIPTION
In Python>=3.8 on Windows, CPython no longers searches for DLLs in
PATH. For `setup.py install` to work, we must force DLLs to be installed.
DLL are included as `data` only if found: Exit on error if DLL not found.

Wheel building (all OSes): Exit if a runtime is not found, to prevent
a wheel being build without the required runtime included.